### PR TITLE
Dependency Updates

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,18 +6,18 @@
     "start": "node app.js"
   },
   "dependencies": {
-    "express": "4.7.2",
-    "jade": "1.5.0",
-    "stylus": "0.47.3",
+    "express": "4.8.8",
+    "jade": "1.6.0",
+    "stylus": "0.48.1",
     "marked": "0.3.2",
-    "mongodb": "1.4.8",
-    "mandrill-api": ">=1.0.2",
-    "bcrypt": "0.7.8",
+    "mongodb": "1.4.10",
+    "mandrill-api": "1.0.40",
+    "bcrypt": "0.8.0",
     "express-csv": "0.6.0",
-    "errorhandler": "1.1.x",
-    "basic-auth-connect": "1.0.x",
-    "morgan": "1.2.x",
-    "body-parser": "1.5.2"
+    "errorhandler": "1.2.0",
+    "basic-auth-connect": "1.0.0",
+    "morgan": "1.3.0",
+    "body-parser": "1.8.0"
   },
   "engines": {
       "node": "0.10.x"


### PR DESCRIPTION
Greetings! Your friendly Depend On bot here with some updates!

I made the following updates:
- stylus -> 0.48.1
- mongodb -> 1.4.10
- express -> 4.8.8
- bcrypt -> 0.8.0
- errorhandler -> 1.2.0
- mandrill-api -> 1.0.40
- morgan -> 1.3.0
- basic-auth-connect -> 1.0.0
- jade -> 1.6.0
- body-parser -> 1.8.0
